### PR TITLE
get validation to work for bootstrap 4

### DIFF
--- a/flask_bootstrap/templates/bootstrap/wtf.html
+++ b/flask_bootstrap/templates/bootstrap/wtf.html
@@ -4,7 +4,7 @@
       {%- if bootstrap_is_hidden_field(form[fieldname]) and hiddens or
              not bootstrap_is_hidden_field(form[fieldname]) and hiddens != 'only' %}
         {%- for error in errors %}
-          <div class="invalid-feedback">{{error}}</div>
+          <div class="invalid-feedback d-block">{{error}}</div>
         {%- endfor %}
       {%- endif %}
     {%- endfor %}
@@ -108,7 +108,7 @@ the necessary fix for required=False attributes, but will also not set the requi
         {%- if field.errors %}
           {%- for error in field.errors %}
             {% call _hz_form_wrap(horizontal_columns, form_type, required=required) %}
-              <div class="invalid-feedback">{{error}}</div>
+              <div class="invalid-feedback d-block">{{error}}</div>
             {% endcall %}
           {%- endfor %}
         {%- elif field.description -%}
@@ -118,15 +118,23 @@ the necessary fix for required=False attributes, but will also not set the requi
         {%- endif %}
       {%- else -%}
         {{field.label(class="form-control-label")|safe}}
-        {% if field.type == 'FileField' %}
-          {{field(class="form-control-file", **kwargs)|safe}}
+        {%- if field.errors %}
+          {% if field.type == 'FileField' %}
+            {{field(class="form-control-file is-invalid", **kwargs)|safe}}
+          {% else %}
+            {{field(class="form-control is-invalid", **kwargs)|safe}}
+          {% endif %}
         {% else %}
-          {{field(class="form-control", **kwargs)|safe}}
+          {% if field.type == 'FileField' %}
+            {{field(class="form-control-file", **kwargs)|safe}}
+          {% else %}
+            {{field(class="form-control", **kwargs)|safe}}
+          {% endif %}
         {% endif %}
 
         {%- if field.errors %}
           {%- for error in field.errors %}
-            <div class="invalid-feedback">{{error}}</div>
+            <div class="invalid-feedback d-block">{{error}}</div>
           {%- endfor %}
         {%- elif field.description -%}
           <small class="form-text text-muted">{{field.description|safe}}</small>


### PR DESCRIPTION
set d-block to get the invalid feedback to show up as red
set is-invalid on the form control for a lovely red border